### PR TITLE
fix: package relative path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ yarn-error.log*
 node_modules/
 
 .DS_Store
+.idea/

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -111,17 +111,12 @@ export default class extends Generator {
 Examples:
 ${chalk.green("some-package")}, ${chalk.green("@my/my-package")} (no version specified, "latest" will be used),
 ${chalk.green("some-package@2.0.1")}, ${chalk.green("@my/my-package@3.0.0")} (specific version specified)
-${chalk.green("../my-package")} (path to a local package, must be relative to: ${chalk.blue(this.destinationRoot())})
+${chalk.green("./my-package")} (path to a local package, must be relative to: ${chalk.blue(this.destinationRoot())})
 
 `,
 				validate: (s) => {
 					// Local package
 					if (s.startsWith(".")) {
-						// First, make sure it's a relative path to a parent directory
-						if (!s.startsWith(`..`)) {
-							return `Invalid path - a relative path to a parent directory is required (must start with: ..)`;
-						}
-
 						// Make sure it doesn't contain invalid path characters
 						if (!isValidPath(s)) {
 							return "Invalid path";
@@ -158,7 +153,7 @@ ${chalk.green("../my-package")} (path to a local package, must be relative to: $
 
 					return true;
 				},
-				default: "../my-package"
+				default: "./my-package"
 			},
 			{
 				type: "input",
@@ -184,6 +179,11 @@ ${chalk.green("../my-package")} (path to a local package, must be relative to: $
 			// use the namespace and the application name as new subdirectory
 			if (props.newdir) {
 				this.destinationRoot(this.destinationPath(`${props.namespace}`));
+
+				// newdir was selected and the components package uses a relative path
+				if (additionalProps.webComponentsPackageVersion.startsWith(".")) {
+					additionalProps.webComponentsPackageVersion = path.relative(this.destinationPath(), additionalProps.webComponentsPackageVersion);
+				}
 			}
 			delete props.newdir;
 

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -20,7 +20,7 @@
 	},
 	"devDependencies": {
 		"@ui5/cli": "^3.2.0",
-		"@ui5/tooling-webc": "0.2.7",
+		"@ui5/tooling-webc": "^0.2.8",
 		"eslint": "^8.43.0",
 		"karma": "^6.4.2",
 		"karma-chrome-launcher": "^3.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,10 @@
 			"dependencies": {
 				"chalk": "^5.2.0",
 				"glob": "^10.2.7",
+				"is-valid-path": "^0.1.1",
 				"package-json": "^8.1.1",
 				"semver": "^7.5.2",
+				"validate-npm-package-name": "^5.0.0",
 				"yeoman-generator": "^5.9.0",
 				"yosay": "^2.0.2"
 			},
@@ -21,13 +23,11 @@
 				"eslint": "^8.42.0",
 				"eslint-plugin-jsdoc": "^46.2.6",
 				"husky": "^8.0.3",
-				"is-valid-path": "^0.1.1",
 				"lint-staged": "^13.2.2",
 				"npm-run-all": "^4.1.5",
 				"prettier": "^2.8.8",
 				"prettier-plugin-properties": "^0.2.0",
 				"pretty-quick": "^3.1.3",
-				"validate-npm-package-name": "^5.0.0",
 				"yeoman-assert": "^3.1.1",
 				"yeoman-test": "^7.4.0"
 			}
@@ -4458,7 +4458,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
 			"integrity": "sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==",
-			"dev": true,
 			"dependencies": {
 				"is-glob": "^2.0.0"
 			},
@@ -4470,7 +4469,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
 			"integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -4479,7 +4477,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
-			"dev": true,
 			"dependencies": {
 				"is-extglob": "^1.0.0"
 			},
@@ -4649,7 +4646,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
 			"integrity": "sha512-+kwPrVDu9Ms03L90Qaml+79+6DZHqHyRoANI6IsZJ/g8frhnfchDOBCa0RbQ6/kdHt5CS5OeIEyrYznNuVN+8A==",
-			"dev": true,
 			"dependencies": {
 				"is-invalid-path": "^0.1.0"
 			},
@@ -14049,7 +14045,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
 			"integrity": "sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==",
-			"dev": true,
 			"requires": {
 				"is-glob": "^2.0.0"
 			},
@@ -14057,14 +14052,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
-					"dev": true
+					"integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww=="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
-					"dev": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -14179,7 +14172,6 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
 			"integrity": "sha512-+kwPrVDu9Ms03L90Qaml+79+6DZHqHyRoANI6IsZJ/g8frhnfchDOBCa0RbQ6/kdHt5CS5OeIEyrYznNuVN+8A==",
-			"dev": true,
 			"requires": {
 				"is-invalid-path": "^0.1.0"
 			}


### PR DESCRIPTION
Currently, the user chooses the UI5 Web Components package first, and only then whether to create a new directory or not. This requires 2 changes:
 - the default value of the local package should be `./my-package` instead of `../my-package` 
 - it the user chooses a new directory, the path is adjusted respectively

Additionally, upgraded to a new version of `@ui5/tooling-webc` to overcome some problems of running newer version web components against the old OpenUI5 1.5 runtime.