### PR TITLE
fix: resolve path for .library.js on windows

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -220,7 +220,7 @@ ${chalk.green("./my-package")} (path to a local package, must be relative to: ${
 			})
 			.forEach((file) => {
 				const sOrigin = this.templatePath(file);
-				const sTarget = this.destinationPath(file.replace(/^_/, "").replace("_library_", this.config.get("libURI")).replace(/\/_/, "/"));
+				const sTarget = this.destinationPath(file.replace(/\\/g, "/").replace(/^_/, "").replace("_library_", this.config.get("libURI")).replace(/\/_/, "/"));
 				this.fs.copyTpl(sOrigin, sTarget, this.config.getAll());
 			});
 	}


### PR DESCRIPTION
It didn't replace the _ for the _.library.js file on windows. Because of that, the prebuild and generate were broken. This solves the problem