### PR TITLE
chore: add the web components package as a dependency

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -32,7 +32,9 @@
 		"npm-run-all": "^4.1.5",
 		"rimraf": "^5.0.1",
 		"typescript": "^5.1.3",
-		"ui5-middleware-livereload": "^0.8.3",
+		"ui5-middleware-livereload": "^0.8.3"
+	},
+	"dependencies": {
 		"<%= webComponentsPackageName %>": "<%= webComponentsPackageVersion %>"
 	}
 }


### PR DESCRIPTION
Currently, the web components package is a `devDependency` to the UI5 library. This is ok for the production build, because the `dist/` will be created and shipped with all files inside (including the webc components runtime), however it is not sufficient for the local development scenario, because the middleware will try to find and transpile the library, and it must be in `node_modules/`